### PR TITLE
fix addseeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +240,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -376,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +414,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -624,6 +677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,7 +862,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "ziggy"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "afl",
  "anyhow",
@@ -814,6 +873,7 @@ dependencies = [
  "honggfuzz",
  "libc",
  "log",
+ "rand",
  "serde_json",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ honggfuzz = { version = "0.5.55", optional = true }
 serde_json = { version = "1.0.105", optional = true }
 log = { version = "0.4.20", optional = true }
 env_logger = { version = "0.10.0", optional = true }
+rand = "0.8"
 libc = "0.2.147"
 
 [features]

--- a/src/bin/cargo-ziggy/add_seeds.rs
+++ b/src/bin/cargo-ziggy/add_seeds.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use rand::Rng;
 use std::{env, process};
 
 impl AddSeeds {
@@ -20,6 +21,7 @@ impl AddSeeds {
         };
 
         let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
+        let mut rng = rand::thread_rng();
         process::Command::new(cargo.clone())
             .args(
                 [
@@ -30,6 +32,7 @@ impl AddSeeds {
                     &format!("-ooutput/{}/afl", self.target),
                     "-V1",
                     "-c-",
+                    &format!("-Saddseeds{}", rng.gen::<u64>()),
                     &timeout_option,
                     &format!("./target/afl/debug/{}", self.target),
                 ]


### PR DESCRIPTION
in the current version the seeds will not be imported if a second addseeds is done before the first one could be picked up by the aflmainfuzzer.

TODO: add the seeds to the shared_corpus for honggfuzz.
