### PR TITLE
Adding coverage feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,6 @@ rand = "0.8"
 libc = "0.2.147"
 
 [features]
+coverage = []
 default = ["cli"]
 cli = ["clap", "console", "glob", "toml", "anyhow", "serde_json", "log", "env_logger"]

--- a/examples/url/Cargo.toml
+++ b/examples/url/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 # url = { git = "https://github.com/servo/rust-url", rev = "bfa167b4e0253642b6766a7aa74a99df60a94048" }
 url = "2.3.1"
 ziggy = { path = "../../", default-features = false }
+
+[features]
+coverage = []

--- a/examples/url/src/main.rs
+++ b/examples/url/src/main.rs
@@ -1,6 +1,8 @@
 fn main() {
     ziggy::fuzz!(|data: &[u8]| {
         if let Ok(s) = std::str::from_utf8(data) {
+            #[cfg(feature = "coverage")]
+            println!("Generating coverage ...");
             #[allow(unused_variables)]
             if let Ok(parsed) = url::Url::parse(s) {
                 #[cfg(not(fuzzing))]

--- a/src/bin/cargo-ziggy/coverage.rs
+++ b/src/bin/cargo-ziggy/coverage.rs
@@ -17,7 +17,7 @@ impl Cover {
 
         // We build the runner with the appropriate flags for coverage
         process::Command::new(cargo)
-            .args(["rustc", "--target-dir=target/coverage"])
+            .args(["rustc", "--target-dir=target/coverage", "-F coverage"])
             .env("RUSTFLAGS", coverage_rustflags)
             .env("RUSTDOCFLAGS", "-Cpanic=unwind")
             .env("CARGO_INCREMENTAL", "0")


### PR DESCRIPTION
Coverage feature can now be used inside harnesses to more context flexibility using ` #[cfg(feature = "coverage")]`