### PR TITLE
Add new flag to pass arguments directly to AFL++

### DIFF
--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -365,7 +365,7 @@ impl Fuzz {
                                 mutation_option,
                                 &timeout_option_afl,
                                 &dictionary_option,
-                                &self.afl_flags,
+                                &self.afl_flags.clone().unwrap_or_default(),
                                 &format!("./target/afl/debug/{}", self.target),
                             ]
                             .iter()

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -365,6 +365,7 @@ impl Fuzz {
                                 mutation_option,
                                 &timeout_option_afl,
                                 &dictionary_option,
+                                &self.afl_flags,
                                 &format!("./target/afl/debug/{}", self.target),
                             ]
                             .iter()

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -150,7 +150,7 @@ pub struct Fuzz {
     start_time: std::time::Instant,
 
     /// Pass flags to AFL++ directly
-    #[clap(short = 'a', long = "afl-flags", value_name = "FLAGS")]
+    #[clap(short = 'a', long = "afl-flags", value_name = "FLAGS", default_value="")]
     afl_flags: String,
 }
 

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -148,6 +148,10 @@ pub struct Fuzz {
     // This value helps us create a global timer for our display
     #[clap(skip=std::time::Instant::now())]
     start_time: std::time::Instant,
+
+    /// Pass
+    #[clap(short = 'f', value_name = "FLAGS", default_value = "")]
+    afl_flags: String,
 }
 
 #[derive(Args)]

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -150,8 +150,8 @@ pub struct Fuzz {
     start_time: std::time::Instant,
 
     /// Pass flags to AFL++ directly
-    #[clap(short = 'a', long = "afl-flags", value_name = "FLAGS", default_value="")]
-    afl_flags: String,
+    #[clap(short, long)]
+    afl_flags: Option<String>,
 }
 
 #[derive(Args)]

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -149,8 +149,8 @@ pub struct Fuzz {
     #[clap(skip=std::time::Instant::now())]
     start_time: std::time::Instant,
 
-    /// Pass
-    #[clap(short = 'f', value_name = "FLAGS", default_value = "")]
+    /// Pass flags to AFL++ directly
+    #[clap(short = 'a', long = "afl-flags", value_name = "FLAGS")]
     afl_flags: String,
 }
 


### PR DESCRIPTION
The `--afl-flags` flag (`-a` for short) takes as an input any flag you would like to give to AFL++ directly.

## Rationale

Sometimes, users want to pass custom flags to AFL++, to enable experimental features for examples.

## Example

```bash
cargo ziggy fuzz -G 43 -a-G42
```

This command will place the second `-G` (with value 42) later in the list of arguments to AFL++, which will result in 42 being used for the biggest input size.

Closes #81.