### PR TITLE
Add build command before minimize

### DIFF
--- a/src/bin/cargo-ziggy/minimize.rs
+++ b/src/bin/cargo-ziggy/minimize.rs
@@ -1,9 +1,15 @@
-use crate::{find_target, FuzzingEngines, Minimize};
+use crate::{find_target, Build, FuzzingEngines, Minimize};
 use anyhow::{Context, Result};
 use std::{env, fs::File, process, thread, time::Duration};
 
 impl Minimize {
     pub fn minimize(&mut self) -> Result<(), anyhow::Error> {
+        let build = Build {
+            no_afl: self.engine == FuzzingEngines::Honggfuzz,
+            no_honggfuzz: self.engine == FuzzingEngines::AFLPlusPlus,
+        };
+        build.build().context("Failed to build the fuzzers")?;
+
         self.target =
             find_target(&self.target).context("⚠️  couldn't find target when minimizing")?;
 


### PR DESCRIPTION
Running `cargo ziggy minimize` did not re-build the fuzzers, which has been a problem in several instances for me in the past.

Now, Honggfuzz and AFL++ targets get built appropriately before minimization.