### PR TITLE
Add support for multiple AFL flag arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,7 +921,7 @@ checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "ziggy"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "afl",
  "anyhow",

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -365,12 +365,12 @@ impl Fuzz {
                                 mutation_option,
                                 &timeout_option_afl,
                                 &dictionary_option,
-                                &self.afl_flags.clone().unwrap_or_default(),
-                                &format!("./target/afl/debug/{}", self.target),
                             ]
                             .iter()
                             .filter(|a| a != &&""),
                         )
+                        .args(self.afl_flags.clone())
+                        .arg(format!("./target/afl/debug/{}", self.target))
                         .env("AFL_AUTORESUME", "1")
                         .env("AFL_TESTCACHE_SIZE", "100")
                         .env("AFL_FAST_CAL", "1")

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -151,7 +151,7 @@ pub struct Fuzz {
 
     /// Pass flags to AFL++ directly
     #[clap(short, long)]
-    afl_flags: Option<String>,
+    afl_flags: Vec<String>,
 }
 
 #[derive(Args)]


### PR DESCRIPTION
Test it out in the url-fuzzer with `cargo ziggy fuzz -a-g40 -a-G50` which should only generate inputs of size `[40; 50] bytes`.

Closes #88.