### PR TITLE
Building in release mode is now possible

### DIFF
--- a/src/bin/cargo-ziggy/build.rs
+++ b/src/bin/cargo-ziggy/build.rs
@@ -17,15 +17,22 @@ impl Build {
 
         if !self.no_afl {
             eprintln!("    {} afl", style("Building").red().bold());
+            let mut afl_args = vec![
+                "afl",
+                "build",
+                "--features=ziggy/afl",
+                "--target-dir=target/afl",
+            ];
+
+            // Add the --release argument if self.release is true
+            if self.release {
+                afl_args.push("--release");
+                info!("Building in release mode");
+            }
 
             // Second fuzzer we build: AFL++
             let run = process::Command::new(cargo.clone())
-                .args([
-                    "afl",
-                    "build",
-                    "--features=ziggy/afl",
-                    "--target-dir=target/afl",
-                ])
+                .args(afl_args)
                 .env("AFL_QUIET", "1")
                 .env("AFL_LLVM_CMPGLOG", "1") // for afl.rs feature "plugins"
                 .env("RUSTFLAGS", env::var("RUSTFLAGS").unwrap_or_default())
@@ -46,9 +53,20 @@ impl Build {
         if !self.no_honggfuzz {
             eprintln!("    {} honggfuzz", style("Building").red().bold());
 
+            let mut hfuzz_args = vec![
+                "hfuzz",
+                "build",
+            ];
+
+            // Add the --release argument if self.release is true
+            if self.release {
+                hfuzz_args.push("--release");
+                info!("Building in release mode");
+            }
+
             // Third fuzzer we build: Honggfuzz
             let run = process::Command::new(cargo)
-                .args(["hfuzz", "build"])
+                .args(hfuzz_args)
                 .env("CARGO_TARGET_DIR", "./target/honggfuzz")
                 .env("HFUZZ_BUILD_ARGS", "--features=ziggy/honggfuzz")
                 .env("RUSTFLAGS", env::var("RUSTFLAGS").unwrap_or_default())

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -46,7 +46,7 @@ impl Fuzz {
     }
 
     pub fn corpus_minimized(&self) -> String {
-        format!("{}/corpus_minimized/", self.output_target(),)
+        format!("{}/corpus_minimized/", self.output_target(), )
     }
 
     pub fn output_target(&self) -> String {
@@ -68,6 +68,7 @@ impl Fuzz {
         let build = Build {
             no_afl: !self.afl(),
             no_honggfuzz: !self.honggfuzz(),
+            release: self.release,
         };
         build.build().context("Failed to build the fuzzers")?;
 
@@ -172,7 +173,7 @@ impl Fuzz {
                     self.output_target(),
                     self.target
                 )
-                .into()]);
+                    .into()]);
 
             for crash_dir in crash_dirs {
                 if let Ok(crashes) = fs::read_dir(crash_dir) {
@@ -181,7 +182,7 @@ impl Fuzz {
                         let to_path = crash_path.join(&file_name);
                         if to_path.exists()
                             || ["", "README.txt", "HONGGFUZZ.REPORT.TXT", "input"]
-                                .contains(&file_name.to_str().unwrap_or_default())
+                            .contains(&file_name.to_str().unwrap_or_default())
                         {
                             continue;
                         }
@@ -198,7 +199,7 @@ impl Fuzz {
                     "{}/afl/mainaflfuzzer/queue/*",
                     self.output_target(),
                 ))?
-                .flatten();
+                    .flatten();
                 for file in afl_corpus {
                     if let Some((file_id, file_name)) = extract_file_id(&file) {
                         if file_id > last_synced_queue_id {
@@ -362,8 +363,8 @@ impl Fuzz {
                                 &timeout_option_afl,
                                 &dictionary_option,
                             ]
-                            .iter()
-                            .filter(|a| a != &&""),
+                                .iter()
+                                .filter(|a| a != &&""),
                         )
                         .args(self.afl_flags.clone())
                         .arg(format!("./target/afl/debug/{}", self.target))
@@ -404,8 +405,8 @@ impl Fuzz {
                 .unwrap_or_default()
                 .contains("dynamic_input")
                 && !std::str::from_utf8(hfuzz_help.stderr.as_slice())
-                    .unwrap_or_default()
-                    .contains("dynamic_input")
+                .unwrap_or_default()
+                .contains("dynamic_input")
             {
                 return Err(anyhow!("Outdated version of honggfuzz, please update the ziggy version in your Cargo.toml or rebuild the project"));
             }
@@ -483,7 +484,7 @@ impl Fuzz {
                     "tail -f {}/logs/honggfuzz.log",
                     self.output_target()
                 ))
-                .bold()
+                    .bold()
             );
         }
 
@@ -790,6 +791,7 @@ impl FuzzingConfig {
 }
 
 use std::fmt;
+
 impl fmt::Display for FuzzingConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -95,6 +95,10 @@ pub struct Build {
     /// No honggfuzz (Fuzz only with AFL++)
     #[clap(long = "no-honggfuzz", action)]
     no_honggfuzz: bool,
+
+    /// Compile in release mode (--release)
+    #[clap(long = "release", action)]
+    release: bool,
 }
 
 #[derive(Args)]
@@ -111,8 +115,14 @@ pub struct Fuzz {
     #[clap(short, long, value_parser, value_name = "DIR")]
     initial_corpus: Option<PathBuf>,
 
+    /// Compile in release mode (--release)
+    #[clap(long = "release", action)]
+    release: bool,
+
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 
     /// Number of concurent fuzzing jobs
@@ -148,7 +158,7 @@ pub struct Fuzz {
     no_honggfuzz: bool,
 
     // This value helps us create a global timer for our display
-    #[clap(skip=std::time::Instant::now())]
+    #[clap(skip = std::time::Instant::now())]
     start_time: std::time::Instant,
 
     /// Pass flags to AFL++ directly
@@ -179,7 +189,9 @@ pub struct Run {
     recursive: bool,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 }
 
@@ -198,7 +210,9 @@ pub struct Minimize {
     output_corpus: PathBuf,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 
     /// Number of concurent minimizing jobs (AFL++ only)
@@ -224,7 +238,9 @@ pub struct Cover {
     input: PathBuf,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 
     /// Source directory of covered code
@@ -255,7 +271,9 @@ pub struct Plot {
     output: PathBuf,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 }
 
@@ -274,7 +292,9 @@ pub struct Triage {
     jobs: u32,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
     /* future feature, wait for casr
     /// Crash directory to be sourced from
@@ -294,7 +314,9 @@ pub struct AddSeeds {
     input: PathBuf,
 
     /// Fuzzers output directory
-    #[clap(short, long, env="ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value=DEFAULT_OUTPUT_DIR)]
+    #[clap(
+        short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
+    )]
     ziggy_output: PathBuf,
 }
 

--- a/src/bin/cargo-ziggy/minimize.rs
+++ b/src/bin/cargo-ziggy/minimize.rs
@@ -7,6 +7,7 @@ impl Minimize {
         let build = Build {
             no_afl: self.engine == FuzzingEngines::Honggfuzz,
             no_honggfuzz: self.engine == FuzzingEngines::AFLPlusPlus,
+            release: false,
         };
         build.build().context("Failed to build the fuzzers")?;
 


### PR DESCRIPTION
User can now build the fuzzers in release mode if wanted by using `--release`.
By default the minimization won't be done in release mode