### PR TITLE
Minor fixes to release mode & refactoring

### DIFF
--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -135,14 +135,6 @@ impl Fuzz {
                 .stderr(process::Stdio::piped())
                 .spawn()?
                 .wait()?;
-
-            // We create an initial corpus file, so that AFL++ starts-up properly
-            let mut initial_corpus = File::create(self.corpus() + "/init")?;
-            writeln!(
-                &mut initial_corpus,
-                "00000000000000000000********0000########111111111111111111111111"
-            )?;
-            drop(initial_corpus);
         }
 
         // We create an initial corpus file, so that AFL++ starts-up properly if corpus is empty
@@ -366,7 +358,13 @@ impl Fuzz {
                 };
                 let target_path = match self.fuzz_binary() {
                     true => self.target.clone(),
-                    false => format!("./target/afl/debug/{}", self.target),
+                    false => {
+                        if self.release {
+                            format!("./target/afl/release/{}", self.target)
+                        } else {
+                            format!("./target/afl/debug/{}", self.target)
+                        }
+                    }
                 };
                 fuzzer_handles.push(
                     process::Command::new(cargo.clone())


### PR DESCRIPTION
**Refactor**
Remove some unnecessary lines that add an `init` input to the corpus, but which will be overwritten further [below](https://github.com/srlabs/ziggy/blob/8d3ad743a074994178323b3e5a605b01d11f8990/src/bin/cargo-ziggy/fuzz.rs#L149).

**Fix**
Actually use the the release build when the `release` flag is set. 