### PR TITLE
Adding init seed only if corpus directory is empty

### DIFF
--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -138,9 +138,12 @@ impl Fuzz {
         }
 
         // We create an initial corpus file, so that AFL++ starts-up properly if corpus is empty
-        let mut initial_corpus = File::create(self.corpus() + "/init")?;
-        writeln!(&mut initial_corpus, "00000000")?;
-        drop(initial_corpus);
+        let is_empty = fs::read_dir(self.corpus())?.next().is_none(); // check if corpus has some seeds
+        if is_empty {
+            let mut initial_corpus = File::create(self.corpus() + "/init")?;
+            writeln!(&mut initial_corpus, "00000000")?;
+            drop(initial_corpus);
+        }
 
         let mut processes = self.spawn_new_fuzzers()?;
 


### PR DESCRIPTION
We now insert the `init` seed containing **00000000** only if the corpus directory is empty. We don't need to add a 'random' seed if our corpus already has some entries