### PR TITLE
Remove dual minimization

### DIFF
--- a/src/bin/cargo-ziggy/build.rs
+++ b/src/bin/cargo-ziggy/build.rs
@@ -76,8 +76,8 @@ impl Build {
         }
 
         if !self.no_honggfuzz {
-            assert_eq!(
-                self.no_afl, self.asan,
+            assert!(
+                !self.asan,
                 "Cannot build honggfuzz with ASAN for the moment. use --no-honggfuzz"
             );
             eprintln!("    {} honggfuzz", style("Building").red().bold());

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -578,9 +578,7 @@ impl Fuzz {
             .map_or(String::from("err"), |corpus| format!("{}", corpus.count()));
 
         let engine = match (self.no_afl, self.no_honggfuzz, self.jobs) {
-            (false, false, 1) => FuzzingEngines::AFLPlusPlus,
-            (false, false, _) => FuzzingEngines::All,
-            (false, true, _) => FuzzingEngines::AFLPlusPlus,
+            (false, _, _) => FuzzingEngines::AFLPlusPlus,
             (true, false, _) => FuzzingEngines::Honggfuzz,
             (true, true, _) => return Err(anyhow!("Pick at least one fuzzer")),
         };

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -27,7 +27,6 @@ pub const DEFAULT_UNMODIFIED_TARGET: &str = "automatically guessed";
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum FuzzingEngines {
-    All,
     AFLPlusPlus,
     Honggfuzz,
 }
@@ -239,7 +238,7 @@ pub struct Minimize {
     #[clap(short, long, value_name = "NUM", default_value_t = 1)]
     jobs: u32,
 
-    #[clap(short, long, value_enum, default_value_t = FuzzingEngines::All)]
+    #[clap(short, long, value_enum, default_value_t = FuzzingEngines::AFLPlusPlus)]
     engine: FuzzingEngines,
 }
 

--- a/tests/url_fuzz.rs
+++ b/tests/url_fuzz.rs
@@ -118,6 +118,18 @@ fn integration() {
         .join("logs")
         .join("minimization_afl.log")
         .is_file());
+
+    // cargo ziggy minimize -e honggfuzz
+    let minimization = process::Command::new(&cargo_ziggy)
+        .arg("ziggy")
+        .arg("minimize")
+        .arg("-ehonggfuzz")
+        .env("ZIGGY_OUTPUT", format!("{}", temp_dir_path.display()))
+        .current_dir(&fuzzer_directory)
+        .status()
+        .expect("failed to run `cargo ziggy minimize`");
+
+    assert!(minimization.success());
     assert!(temp_dir_path
         .join("url-fuzz")
         .join("logs")


### PR DESCRIPTION
Minimization with both AFL++ and honggfuzz produces a bunch of duplicates in the corpus, and takes a long time.

I never use it and always set `-e afl-plus-plus`. Hence, I'm proposing to remove the option.