### PR TITLE
Change the runner behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,15 +214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "fork"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e74d3423998a57e9d906e49252fb79eb4a04d5cdfe188fb1b7ff9fc076a8ed"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +697,6 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "console",
- "fork",
  "glob",
  "honggfuzz",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ anyhow = { version = "1.0.83", optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 clap = { version = "4.5.4", features = ["cargo", "derive", "env"], optional = true }
 console = { version = "0.15.8", optional = true }
-fork = { version = "0.1.23", optional = true }
 glob = { version = "0.3.1", optional = true }
 honggfuzz = { version = "0.5.56", optional = true }
 libc = { version = "0.2.153", optional = true }
@@ -43,7 +42,6 @@ cli = [
     "cargo_metadata",
     "twox-hash",
 ]
-coverage = ["fork", "libc"]
 
 [lints.clippy]
 needless_doctest_main = "allow"

--- a/src/bin/cargo-ziggy/run.rs
+++ b/src/bin/cargo-ziggy/run.rs
@@ -65,7 +65,7 @@ impl Run {
         let input_files: Vec<PathBuf> = self
             .inputs
             .iter()
-            .map(|x| {
+            .flat_map(|x| {
                 let canonical_name = x
                     .display()
                     .to_string()
@@ -83,7 +83,6 @@ impl Run {
                     false => vec![path],
                 }
             })
-            .flatten()
             .collect();
 
         let runner_path = match self.asan {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,116 +1,30 @@
 #![doc = include_str!("../README.md")]
 #[cfg(feature = "afl")]
 pub use afl::fuzz as afl_fuzz;
-#[cfg(feature = "coverage")]
-pub use fork;
 #[cfg(feature = "honggfuzz")]
 pub use honggfuzz::fuzz as honggfuzz_fuzz;
 
 // This is our inner harness handler function for the runner.
 // We open the input file and feed the data to the harness closure.
 #[doc(hidden)]
-#[cfg(not(any(feature = "afl", feature = "honggfuzz", feature = "coverage")))]
-pub fn read_file_and_fuzz<F>(mut closure: F, file: String)
-where
-    F: FnMut(&[u8]),
-{
-    use std::{fs::File, io::Read};
-    println!("Now running file {file}");
-    let mut buffer: Vec<u8> = Vec::new();
-    match File::open(file) {
-        Ok(mut f) => {
-            match f.read_to_end(&mut buffer) {
-                Ok(_) => {
-                    closure(buffer.as_slice());
-                }
-                Err(e) => {
-                    println!("Could not get data from file: {e}");
-                }
-            };
-        }
-        Err(e) => {
-            println!("Error opening file: {e}");
-        }
-    };
-}
-
-// This is our special coverage harness runner.
-// We open the input file and feed the data to the harness closure.
-// The difference with the runner is that we catch any kind of panic.
-#[cfg(feature = "coverage")]
-pub fn read_file_and_fuzz<F>(mut closure: F, file: String)
-where
-    F: FnMut(&[u8]),
-{
-    use std::{fs::File, io::Read, process::exit};
-    println!("Now running file {file} for coverage");
-    let mut buffer: Vec<u8> = Vec::new();
-    match File::open(file) {
-        Ok(mut f) => {
-            match f.read_to_end(&mut buffer) {
-                Ok(_) => {
-                    use crate::fork::{fork, Fork};
-
-                    match fork() {
-                        Ok(Fork::Parent(child)) => {
-                            println!(
-                                "Continuing execution in parent process, new child has pid: {}",
-                                child
-                            );
-                            unsafe {
-                                let mut status = 0i32;
-                                let _ = libc::waitpid(child, &mut status, 0);
-                            }
-                            println!("Child is done, moving on");
-                        }
-                        Ok(Fork::Child) => {
-                            closure(buffer.as_slice());
-                            exit(0);
-                        }
-                        Err(_) => println!("Fork failed"),
-                    }
-                }
-                Err(e) => {
-                    println!("Could not get data from file: {e}");
-                }
-            };
-        }
-        Err(e) => {
-            println!("Error opening file: {e}");
-        }
-    };
-}
-
-// This is our middle harness handler macro for the runner and for coverage.
-// We read input files and directories from the command line and run the inner harness `fuzz`.
-#[doc(hidden)]
-#[macro_export]
 #[cfg(not(any(feature = "afl", feature = "honggfuzz")))]
-macro_rules! read_args_and_fuzz {
-    ( |$buf:ident| $body:block ) => {
-        use std::{env, fs};
-        let args: Vec<String> = env::args().collect();
-        for path in &args[1..] {
-            if let Ok(metadata) = fs::metadata(&path) {
-                let files = match metadata.is_dir() {
-                    true => fs::read_dir(&path)
-                        .unwrap()
-                        .map(|x| x.unwrap().path())
-                        .filter(|x| x.is_file())
-                        .map(|x| x.to_str().unwrap().to_string())
-                        .collect::<Vec<String>>(),
-                    false => vec![path.to_string()],
-                };
-
-                for file in files {
-                    $crate::read_file_and_fuzz(|$buf| $body, file);
-                }
-                println!("Finished reading all files");
-            } else {
-                println!("Could not read metadata for {path}");
-            }
-        }
-    };
+pub fn run_file<F>(mut closure: F)
+where
+    F: FnMut(&[u8]),
+{
+    use std::{env, fs::File, io::Read};
+    let file_name: String = env::args().nth(1).expect("pass in a file name as argument");
+    println!("Now running {file_name}");
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut file = File::open(file_name).unwrap_or_else(|e| {
+        eprintln!("Could not open file: {e}");
+        std::process::exit(1);
+    });
+    file.read_to_end(&mut buffer).unwrap_or_else(|e| {
+        eprintln!("Could not read file: {e}");
+        std::process::exit(1);
+    });
+    closure(buffer.as_slice());
 }
 
 /// Fuzz a closure-like block of code by passing an object of arbitrary type.
@@ -137,13 +51,13 @@ macro_rules! read_args_and_fuzz {
 #[cfg(not(any(feature = "afl", feature = "honggfuzz")))]
 macro_rules! fuzz {
     (|$buf:ident| $body:block) => {
-        $crate::read_args_and_fuzz!(|$buf| $body);
+        $crate::run_file(|$buf| $body);
     };
     (|$buf:ident: &[u8]| $body:block) => {
-        $crate::read_args_and_fuzz!(|$buf| $body);
+        $crate::run_file(|$buf| $body);
     };
     (|$buf:ident: $dty: ty| $body:block) => {
-        $crate::read_args_and_fuzz!(|$buf| {
+        $crate::run_file(|$buf| {
             let $buf: $dty = {
                 let mut data = ::arbitrary::Unstructured::new($buf);
                 if let Ok(d) = ::arbitrary::Arbitrary::arbitrary(&mut data).map_err(|_| "") {


### PR DESCRIPTION
New behavior:

```bash
cargo ziggy run -i path/to/corpora/      # executes all files and does not stop on a crash
cargo ziggy run -x -i path/to/corpora/   # executes files and stops if a crash is found
# keep the `-r` flag for recursion
# keep the `-G` flag for max input length
```

- [x] Move the file-discovery code from the runner harness to `cargo-ziggy`
- [ ] Create the `-x` flag
- [ ] Make sure the coverage generates even if there are crashes in the corpora