### PR TITLE
run only 1 sanitized binary

### DIFF
--- a/src/bin/cargo-ziggy/build.rs
+++ b/src/bin/cargo-ziggy/build.rs
@@ -30,7 +30,7 @@ impl Build {
 
             // Add the --release argument if self.release is true
             if self.release {
-                assert!(!self.release, "cannot use --release for ASAN builds");
+                assert!(!self.asan, "cannot use --release for ASAN builds");
                 afl_args.push("--release");
             }
 
@@ -63,6 +63,7 @@ impl Build {
 
             // If ASAN is enabled, build both a sanitized binary and a non-sanitized binary.
             if self.asan {
+                eprintln!("    {} afl (ASan)", style("Building").red().bold());
                 assert_eq!(opt_level, "0", "AFL_OPT_LEVEL must be 0 for ASAN builds");
                 afl_args.push(&asan_target_str);
                 afl_args.extend(["-Z", "build-std"]);

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -481,7 +481,7 @@ impl Fuzz {
                     false => {
                         if self.release {
                             format!("./target/afl/release/{}", self.target)
-                        } else if self.asan {
+                        } else if self.asan && job_num == 0 {
                             format!("./target/afl/{ASAN_TARGET}/debug/{}", self.target)
                         } else {
                             format!("./target/afl/debug/{}", self.target)


### PR DESCRIPTION
Currently, when fuzzing with multiple cores and ASAN enabled, we use the sanitized binary on all cores. This is unnecessary and degrades performance; instead, use the ASAN-compiled binary only on the first core.

Since we need two binaries for this, compile both a sanitized version and a not sanitized version if `ASAN` is enabled.