### PR TITLE
Added --features flag to the run command

### DIFF
--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -217,6 +217,10 @@ pub struct Run {
     /// Build with ASAN (nightly only)
     #[clap(long = "asan", action)]
     asan: bool,
+
+    /// Activate these features on the target
+    #[clap(short = 'F', long, num_args = 0..)]
+    features: Vec<String>,
 }
 
 #[derive(Args, Clone)]

--- a/src/bin/cargo-ziggy/run.rs
+++ b/src/bin/cargo-ziggy/run.rs
@@ -20,6 +20,10 @@ impl Run {
         let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_default();
         let mut rust_doc_flags = env::var("RUSTDOCFLAGS").unwrap_or_default();
 
+        for feature in &self.features {
+            args.extend(["-F", feature.as_str()]);
+        }
+
         if self.asan {
             args.push(&asan_target_str);
             args.extend(["-Z", "build-std"]);


### PR DESCRIPTION
To enable specific features on the target when executing `cargo ziggy run`, the -F / --features flag can now be used. It is simply passed along to rustc.

This can be useful when examining a crash in a more complex target. For example, verbose logging in the target could be hidden behind a "logging" feature, to reduce noise when fuzzing. In case the output is needed for crash analysis, it could simply be activated by running `cargo ziggy run -F logging`.