### PR TITLE
add -m memory_limit option for afl++, rename -m for minimize to -M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 1.3.2 -
+
+- add -m memory limit for AFL++ fuzz option
+- moved previous -m minimize option to -M
+- Update `afl.rs` to `0.15.16`
+
+## 1.3.1 - 2025-02-26
+
+- AFL++ fuzz targets now can be used for replays by given input files as
+  command line parameters
+
 ## 1.3.0 - 2024-11-05
 
 - Fix bugs (#102 and #103)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "afl"
-version = "0.15.11"
+version = "0.15.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bb240a3b9ff18002142c1a736e98046461d51a694d687c3e7329b456ab0fe4"
+checksum = "374ce830a032af7091cb68081644c991adb0e7636f9528c503beaa2a06162602"
 dependencies = [
  "home",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [dependencies]
-afl = { version = "0.15.11", default-features = false, optional = true }
+afl = { version = "0.15.16", default-features = false, optional = true }
 anyhow = { version = "1.0.83", optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 clap = { version = "4.5.4", features = ["cargo", "derive", "env"], optional = true }

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -453,6 +453,10 @@ impl Fuzz {
                     Some(t) => format!("-t{}", t * 1000),
                     None => String::new(),
                 };
+                let memory_option_afl = match &self.memory_limit {
+                    Some(m) => format!("-m{}", m),
+                    None => String::new(),
+                };
                 let dictionary_option = match &self.dictionary {
                     Some(d) => format!("-x{}", &d.display().to_string()),
                     None => String::new(),
@@ -516,6 +520,7 @@ impl Fuzz {
                                 mutation_option,
                                 input_format_option,
                                 &timeout_option_afl,
+                                &memory_option_afl,
                                 &dictionary_option,
                             ]
                             .iter()

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -133,8 +133,12 @@ pub struct Fuzz {
     #[clap(short, long, value_name = "SECS")]
     timeout: Option<u32>,
 
+    /// Memory limit for the fuzz target (AFL++ only)
+    #[clap(short, long, value_name = "STRING")]
+    memory_limit: Option<String>,
+
     /// Perform initial minimization
-    #[clap(short, long, action, default_value_t = false)]
+    #[clap(short = 'M', long, action, default_value_t = false)]
     minimize: bool,
 
     /// Dictionary file (format:<http://llvm.org/docs/LibFuzzer.html#dictionaries>)


### PR DESCRIPTION
WDYT?
-m is the parameter for afl-fuzz, so it is more intuitive, which requires moving minimizing to -M
