### PR TITLE
Coverage: Verify that the source directory exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,14 +265,15 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.56"
+version = "0.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c76b6234c13c9ea73946d1379d33186151148e0da231506b964b44f3d023505"
+checksum = "fc563d4f41b17364d5c48ded509f2bcf1c3f6ae9c7f203055b4a5c325072d57e"
 dependencies = [
  "arbitrary",
  "lazy_static",
  "memmap2",
  "rustc_version",
+ "semver",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.5.4", features = ["cargo", "derive", "env"], optional = tr
 console = { version = "0.15.8", optional = true }
 fork = { version = "0.1.23", optional = true }
 glob = { version = "0.3.1", optional = true }
-honggfuzz = { version = "0.5.56", optional = true }
+honggfuzz = { version = "0.5.57", optional = true }
 libc = { version = "0.2.153", optional = true }
 semver = { version = "1.0.23", optional = true }
 strip-ansi-escapes = { version = "0.2.0", optional = true }

--- a/src/bin/cargo-ziggy/coverage.rs
+++ b/src/bin/cargo-ziggy/coverage.rs
@@ -15,6 +15,14 @@ impl Cover {
         self.target =
             find_target(&self.target).context("⚠️  couldn't find the target to start coverage")?;
 
+        if let Some(path) = &self.source {
+            if !path.try_exists()? {
+                return Err(anyhow!(
+                    "Source directory specified, but path does not exist!"
+                ));
+            }
+        }
+
         // build the runner
         Cover::build_runner()?;
 

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -385,7 +385,7 @@ impl Fuzz {
                 // not apply more than 4 jobs to honggfuzz
                 match self.jobs {
                     1 => (1, 0),
-                    2..=12 => (self.jobs - ((self.jobs + 2) / 3), (self.jobs + 2) / 3),
+                    2..=12 => (self.jobs - self.jobs.div_ceil(3), self.jobs.div_ceil(3)),
                     _ => (self.jobs - 4, 4),
                 }
             }


### PR DESCRIPTION
This prevents frustration, especially on large corpora.