### PR TITLE
small bugfix for `cargo ziggy cover` if custom `RUSTFLAGS` are set

### DIFF
--- a/src/bin/cargo-ziggy/coverage.rs
+++ b/src/bin/cargo-ziggy/coverage.rs
@@ -95,12 +95,9 @@ impl Cover {
         // The cargo executable
         let cargo = env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
 
-        let mut coverage_rustflags = env::var("COVERAGE_RUSTFLAGS")
-            .unwrap_or_else(|_| String::from("-Cinstrument-coverage"));
-        if let Ok(env_rustflags) = &env::var("RUSTFLAGS") {
-            coverage_rustflags.push(' ');
-            coverage_rustflags.push_str(env_rustflags);
-        }
+        let mut coverage_rustflags =
+            env::var("COVERAGE_RUSTFLAGS").unwrap_or("-Cinstrument-coverage ".to_string());
+        coverage_rustflags.push_str(&env::var("RUSTFLAGS").unwrap_or_default());
 
         let build = process::Command::new(cargo)
             .args([


### PR DESCRIPTION
Executing `cargo ziggy cover` failed with `error: unknown codegen option: 'instrument-coverage--cfg'` if the `RUSTFLAGS` env variable was set. Prefixing our custom flags with a space in that scenario fixes the bug.