### PR TITLE
add a timeout option for `cargo ziggy triage`

### DIFF
--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -328,6 +328,10 @@ pub struct Triage {
         short, long, env = "ZIGGY_OUTPUT", value_parser, value_name = "DIR", default_value = DEFAULT_OUTPUT_DIR
     )]
     ziggy_output: PathBuf,
+
+    /// Terminate runner after x seconds
+    #[clap(short, long, value_name = "SECS")]
+    timeout: Option<u32>,
     /* future feature, wait for casr
     /// Crash directory to be sourced from
     #[clap(short, long, value_parser, value_name = "DIR", default_value = DEFAULT_CRASHES_DIR)]

--- a/src/bin/cargo-ziggy/triage.rs
+++ b/src/bin/cargo-ziggy/triage.rs
@@ -41,6 +41,7 @@ impl Triage {
                     "-o",
                     &triage_dir,
                     &format!("-j{}", self.jobs),
+                    &format!("-t{}", self.timeout.unwrap_or(0))
                     // future: add option for crashes directory and use runner
                 ]
                 .iter()


### PR DESCRIPTION
When an input does not lead to a crash (e.g. due to it stemming from a fuzzing run with an old binary), the instrumented binary just waits for more input on stdin instead of terminating. This stalls casr-afl. By providing a timeout, this behavior can be circumvented. 