### PR TITLE
Don't run actions twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Cargo Build & Test
 
 on:
   push:
-  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Because the on push event is triggered for all branches, the workflow will also execute whenever a PR is opened or updated. Additionally specifying on pull_request triggers the actions twice, wasting time and resources.