### PR TITLE
Fix honggfuzz build failure with binutils-2.46

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.58"
+version = "0.5.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8319f3cc8fe416e7aa1ab95dcc04fd49f35397a47d0b2f0f225f6dba346a07"
+checksum = "9724607fd5cc535fceca960d7f684a1735c4e96c26b4e43986fe8ce798c2550e"
 dependencies = [
  "arbitrary",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo_metadata = { version = "0.23.1", optional = true }
 clap = { version = "4.5.60", features = ["cargo", "derive", "env"], optional = true }
 console = { version = "0.16.2", optional = true }
 glob = { version = "0.3.3", optional = true }
-honggfuzz = { version = "0.5.58", optional = true }
+honggfuzz = { version = "0.5.59", optional = true }
 libc = { version = "0.2.182", optional = true }
 semver = { version = "1.0.27", optional = true }
 strip-ansi-escapes = { version = "0.2.1", optional = true }


### PR DESCRIPTION
This is done by updating to the newest honggfuzz version.