### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt-get install binutils-dev libunwind-dev gnuplot
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: rustup component add rust-src
+      - run: rustup component add rust-src llvm-tools
       - run: cargo install cargo-afl honggfuzz grcov
       - run: cargo install --path . --verbose
       - run: cargo test --verbose -- --show-output

--- a/src/bin/cargo-ziggy/coverage.rs
+++ b/src/bin/cargo-ziggy/coverage.rs
@@ -131,7 +131,7 @@ impl Cover {
         coverage_dir: &str,
         source_or_workspace_root: &str,
     ) -> Result<(), anyhow::Error> {
-        process::Command::new("grcov")
+        let coverage = process::Command::new("grcov")
             .args([
                 ".",
                 &format!("-b=./target/coverage/debug/{target}"),
@@ -146,6 +146,9 @@ impl Cover {
             .context("⚠️  cannot find grcov in your path, please install it")?
             .wait()
             .context("⚠️  couldn't wait for the grcov process")?;
+        if dbg!(!coverage.success()) {
+            bail!("⚠️  grcov failed");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Even though grcov's zero exit status can happen with fatal erros, check the status. Additionally add the missing llvm-tools component via rustup.