### PR TITLE
Edition 2024 (upgrade from 2021)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -31,15 +31,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -147,9 +147,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -181,25 +181,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys",
 ]
@@ -264,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +283,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -296,8 +307,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -305,6 +329,21 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -323,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.59"
+version = "0.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724607fd5cc535fceca960d7f684a1735c4e96c26b4e43986fe8ce798c2550e"
+checksum = "4d6510a410acedd7a7683b3a45dafdc5ccf3c72d6addaa373497005964fc4e23"
 dependencies = [
  "arbitrary",
  "lazy_static",
@@ -416,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +479,18 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -457,15 +514,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -478,10 +535,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -494,6 +557,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -512,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -553,6 +622,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +654,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -602,7 +687,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -788,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -852,6 +937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,10 +999,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.114"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -922,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -932,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -945,11 +1045,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -982,6 +1116,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -1020,18 +1236,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ziggy"
 version = "1.5.4"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "A multi-fuzzer management utility for all of your Rust fuzzing needs 🧑‍🎤"
 repository = "https://github.com/srlabs/ziggy/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ coverage = []
 afl = { version = "0.17.1", default-features = false, optional = true }
 anyhow = { version = "1.0.102", optional = true }
 cargo_metadata = { version = "0.23.1", optional = true }
-clap = { version = "4.5.60", features = ["cargo", "derive", "env"], optional = true }
-console = { version = "0.16.2", optional = true }
+clap = { version = "4.6.0", features = ["cargo", "derive", "env"], optional = true }
+console = { version = "0.16.3", optional = true }
 glob = { version = "0.3.3", optional = true }
-honggfuzz = { version = "0.5.59", optional = true }
+honggfuzz = { version = "0.5.60", optional = true }
 indicatif = { version = "0.18.4", optional = true }
-libc = { version = "0.2.182", optional = true }
+libc = { version = "0.2.183", optional = true }
 rayon = { version = "1.11.0", optional = true }
 semver = { version = "1.0.27", optional = true }
 signal-hook = { version = "0.4.3", optional = true }

--- a/examples/asan/src/main.rs
+++ b/examples/asan/src/main.rs
@@ -5,7 +5,7 @@ fn main() {
         }
         if data[0] == b'f' && data[1] == b'u' && data[2] == b'z' && data[3] == b'z' {
             let xs = [0, 1, 2, 3];
-            let _y = unsafe { *xs.as_ptr().offset(4) };
+            let _y = unsafe { *xs.as_ptr().add(4) };
         }
     });
 }

--- a/src/bin/cargo-ziggy/add_seeds.rs
+++ b/src/bin/cargo-ziggy/add_seeds.rs
@@ -22,7 +22,9 @@ impl AddSeeds {
             .context("could not parse cargo-afl version")?
             .map(|v| req.matches(&v))?
         {
-            bail!("Outdated version of cargo-afl, ziggy needs >=0.14.5, please run `cargo install cargo-afl`");
+            bail!(
+                "Outdated version of cargo-afl, ziggy needs >=0.14.5, please run `cargo install cargo-afl`"
+            );
         }
 
         let target = find_target(&self.target)?;

--- a/src/bin/cargo-ziggy/build.rs
+++ b/src/bin/cargo-ziggy/build.rs
@@ -1,5 +1,5 @@
 use crate::Build;
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use console::style;
 use std::{env, process};
 

--- a/src/bin/cargo-ziggy/clean.rs
+++ b/src/bin/cargo-ziggy/clean.rs
@@ -1,5 +1,5 @@
 use crate::Clean;
-use anyhow::{bail, Error};
+use anyhow::{Error, bail};
 use std::{env, process::Command};
 
 impl Clean {

--- a/src/bin/cargo-ziggy/coverage.rs
+++ b/src/bin/cargo-ziggy/coverage.rs
@@ -1,5 +1,5 @@
-use crate::{find_target, Cover};
-use anyhow::{bail, Context, Result};
+use crate::{Cover, find_target};
+use anyhow::{Context, Result, bail};
 use cargo_metadata::camino::Utf8PathBuf;
 use glob::glob;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -27,10 +27,10 @@ impl Cover {
         self.target =
             find_target(&self.target).context("⚠️  couldn't find the target to start coverage")?;
 
-        if let Some(path) = &self.source {
-            if !path.try_exists()? {
-                bail!("Source directory specified, but path does not exist!");
-            }
+        if let Some(path) = &self.source
+            && !path.try_exists()?
+        {
+            bail!("Source directory specified, but path does not exist!");
         }
 
         // build the runner

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -1,6 +1,6 @@
 use crate::*;
-use anyhow::{anyhow, bail, Error};
-use console::{style, Term};
+use anyhow::{Error, anyhow, bail};
+use console::{Term, style};
 use glob::glob;
 use std::{
     fs::File,
@@ -263,23 +263,24 @@ impl Fuzz {
                 });
             }
 
-            if !afl_output_ok {
-                if let Ok(afl_log) =
+            if !afl_output_ok
+                && let Ok(afl_log) =
                     fs::read_to_string(format!("{}/logs/afl.log", self.output_target()))
+            {
+                if afl_log.contains("ready to roll") {
+                    afl_output_ok = true;
+                } else if afl_log.contains("/proc/sys/kernel/core_pattern")
+                    || afl_log.contains("/sys/devices/system/cpu")
                 {
-                    if afl_log.contains("ready to roll") {
-                        afl_output_ok = true;
-                    } else if afl_log.contains("/proc/sys/kernel/core_pattern")
-                        || afl_log.contains("/sys/devices/system/cpu")
-                    {
-                        stop_fuzzers(&processes)?;
-                        eprintln!("We highly recommend you configure your system for better performance:\n");
-                        eprintln!("    cargo afl system-config\n");
-                        eprintln!(
-                            "Or set AFL_SKIP_CPUFREQ and AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES\n"
-                        );
-                        return Ok(());
-                    }
+                    stop_fuzzers(&processes)?;
+                    eprintln!(
+                        "We highly recommend you configure your system for better performance:\n"
+                    );
+                    eprintln!("    cargo afl system-config\n");
+                    eprintln!(
+                        "Or set AFL_SKIP_CPUFREQ and AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES\n"
+                    );
+                    return Ok(());
                 }
             }
 
@@ -365,12 +366,13 @@ impl Fuzz {
         let queue_path = PathBuf::from(format!("{}/queue", self.output_target()));
         let corpus_path = PathBuf::from(format!("{}/corpus", self.output_target()));
         for (file, fuzzer) in new_files {
-            if matches!(fuzzer, Fuzzer::Afl) && self.honggfuzz() {
-                if let Some(file_name) = file.file_name() {
-                    let target = queue_path.join(file_name);
-                    if !target.exists() {
-                        let _ = fs::copy(&file, target);
-                    }
+            if matches!(fuzzer, Fuzzer::Afl)
+                && self.honggfuzz()
+                && let Some(file_name) = file.file_name()
+            {
+                let target = queue_path.join(file_name);
+                if !target.exists() {
+                    let _ = fs::copy(&file, target);
                 }
             }
             // Hash the file to get its file name
@@ -775,7 +777,9 @@ impl Fuzz {
                 term.move_cursor_up(1)?;
 
                 if new_corpus_size == *"err" || new_corpus_size == *"0" {
-                    bail!("Please check the logs and make sure the right versions of the fuzzers are installed");
+                    bail!(
+                        "Please check the logs and make sure the right versions of the fuzzers are installed"
+                    );
                 }
                 term.write_line(&format!(
                     "{} the corpus ({} -> {} files)             \n",
@@ -952,35 +956,57 @@ impl Fuzz {
         let mut screen = String::new();
         // We start by clearing the screen
         screen += "\x1B[1;1H\x1B[2J";
-        screen += &format!("┌─ {blue}ziggy{reset} {purple}rocking{reset} ─────────{fuzzer_name:─^25.25}──────────────────{blue}/{red}////{reset}──┐\n");
+        screen += &format!(
+            "┌─ {blue}ziggy{reset} {purple}rocking{reset} ─────────{fuzzer_name:─^25.25}──────────────────{blue}/{red}////{reset}──┐\n"
+        );
         screen += &format!(
             "│{gray}run time :{reset} {total_run_time:17.17}                                       {blue}/{red}///{reset}    │\n"
         );
-        screen += &format!("├─ {blue}afl++{reset} {afl_status:0}─────────────────────────────────────────────────────{blue}/{red}///{reset}─┤\n");
+        screen += &format!(
+            "├─ {blue}afl++{reset} {afl_status:0}─────────────────────────────────────────────────────{blue}/{red}///{reset}─┤\n"
+        );
         if !afl_status.contains("disabled") {
-            screen += &format!("│       {gray}instances :{reset} {afl_instances:17.17} │ {gray}best coverage :{reset} {afl_coverage:11.11}   {blue}/{red}//{reset}   │\n");
+            screen += &format!(
+                "│       {gray}instances :{reset} {afl_instances:17.17} │ {gray}best coverage :{reset} {afl_coverage:11.11}   {blue}/{red}//{reset}   │\n"
+            );
             if afl_crashes == "0" {
-                screen += &format!("│{gray}cumulative speed :{reset} {afl_speed:17.17} │ {gray}crashes saved :{reset} {afl_crashes:11.11}  {blue}/{red}/{reset}     │\n");
+                screen += &format!(
+                    "│{gray}cumulative speed :{reset} {afl_speed:17.17} │ {gray}crashes saved :{reset} {afl_crashes:11.11}  {blue}/{red}/{reset}     │\n"
+                );
             } else {
-                screen += &format!("│{gray}cumulative speed :{reset} {afl_speed:17.17} │ {gray}crashes saved :{reset} {red}{afl_crashes:11.11}{reset}  {blue}/{red}/{reset}     │\n");
+                screen += &format!(
+                    "│{gray}cumulative speed :{reset} {afl_speed:17.17} │ {gray}crashes saved :{reset} {red}{afl_crashes:11.11}{reset}  {blue}/{red}/{reset}     │\n"
+                );
             }
             screen += &format!(
                 "│     {gray}total execs :{reset} {afl_total_execs:17.17} │{gray}timeouts saved :{reset} {afl_timeouts:17.17}   │\n"
             );
-            screen += &format!("│ {gray}top inputs todo :{reset} {afl_faves:17.17} │   {gray}no find for :{reset} {afl_new_finds:17.17}   │\n");
+            screen += &format!(
+                "│ {gray}top inputs todo :{reset} {afl_faves:17.17} │   {gray}no find for :{reset} {afl_new_finds:17.17}   │\n"
+            );
         }
         screen += &format!(
             "├─ {blue}honggfuzz{reset} {hf_status:0}─────────────────────────────────────────────────┬────┘\n"
         );
         if !hf_status.contains("disabled") {
-            screen += &format!("│      {gray}threads :{reset} {hf_threads:17.17} │      {gray}coverage :{reset} {hf_coverage:17.17} │\n");
+            screen += &format!(
+                "│      {gray}threads :{reset} {hf_threads:17.17} │      {gray}coverage :{reset} {hf_coverage:17.17} │\n"
+            );
             if hf_crashes == "0" {
-                screen += &format!("│{gray}average speed :{reset} {hf_speed:17.17} │ {gray}crashes saved :{reset} {hf_crashes:17.17} │\n");
+                screen += &format!(
+                    "│{gray}average speed :{reset} {hf_speed:17.17} │ {gray}crashes saved :{reset} {hf_crashes:17.17} │\n"
+                );
             } else {
-                screen += &format!("│{gray}average speed :{reset} {hf_speed:17.17} │ {gray}crashes saved :{reset} {red}{hf_crashes:17.17}{reset} │\n");
+                screen += &format!(
+                    "│{gray}average speed :{reset} {hf_speed:17.17} │ {gray}crashes saved :{reset} {red}{hf_crashes:17.17}{reset} │\n"
+                );
             }
-            screen += &format!("│  {gray}total execs :{reset} {hf_total_execs:17.17} │{gray}timeouts saved :{reset} {hf_timeouts:17.17} │\n");
-            screen += &format!("│                                  │   {gray}no find for :{reset} {hf_new_finds:17.17} │\n");
+            screen += &format!(
+                "│  {gray}total execs :{reset} {hf_total_execs:17.17} │{gray}timeouts saved :{reset} {hf_timeouts:17.17} │\n"
+            );
+            screen += &format!(
+                "│                                  │   {gray}no find for :{reset} {hf_new_finds:17.17} │\n"
+            );
         }
         if self.coverage_worker {
             screen += &format!(

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -10,12 +10,12 @@ mod triage;
 mod util;
 
 use crate::fuzz::FuzzingConfig;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use std::{
     fs,
     path::PathBuf,
-    sync::{atomic::AtomicBool, Arc},
+    sync::{Arc, atomic::AtomicBool},
 };
 
 pub const DEFAULT_UNMODIFIED_TARGET: &str = "automatically guessed";

--- a/src/bin/cargo-ziggy/minimize.rs
+++ b/src/bin/cargo-ziggy/minimize.rs
@@ -1,5 +1,5 @@
-use crate::{find_target, Build, FuzzingEngines, Minimize};
-use anyhow::{bail, Context, Result};
+use crate::{Build, FuzzingEngines, Minimize, find_target};
+use anyhow::{Context, Result, bail};
 use std::{
     env,
     fs::{self, File},

--- a/src/bin/cargo-ziggy/plot.rs
+++ b/src/bin/cargo-ziggy/plot.rs
@@ -1,4 +1,4 @@
-use crate::{find_target, Plot};
+use crate::{Plot, find_target};
 use anyhow::{Context, Result};
 use std::{env, process};
 

--- a/src/bin/cargo-ziggy/run.rs
+++ b/src/bin/cargo-ziggy/run.rs
@@ -1,5 +1,5 @@
-use crate::{find_target, Run};
-use anyhow::{bail, Context, Result};
+use crate::{Run, find_target};
+use anyhow::{Context, Result, bail};
 use console::style;
 use std::{
     collections::HashSet,

--- a/tests/arbitrary_fuzz.rs
+++ b/tests/arbitrary_fuzz.rs
@@ -62,12 +62,14 @@ fn integration() {
     thread::sleep(Duration::from_secs(30));
     kill_subprocesses_recursively(&format!("{}", fuzzer.id()));
 
-    assert!(temp_dir_path
-        .join("arbitrary-fuzz")
-        .join("afl")
-        .join("mainaflfuzzer")
-        .join("fuzzer_stats")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("arbitrary-fuzz")
+            .join("afl")
+            .join("mainaflfuzzer")
+            .join("fuzzer_stats")
+            .is_file()
+    );
     assert!(
         fs::read_dir(
             temp_dir_path
@@ -80,10 +82,12 @@ fn integration() {
         .count()
             != 0
     );
-    assert!(temp_dir_path
-        .join("arbitrary-fuzz")
-        .join("honggfuzz")
-        .join("arbitrary-fuzz")
-        .join("input")
-        .is_dir());
+    assert!(
+        temp_dir_path
+            .join("arbitrary-fuzz")
+            .join("honggfuzz")
+            .join("arbitrary-fuzz")
+            .join("input")
+            .is_dir()
+    );
 }

--- a/tests/asan_fuzz.rs
+++ b/tests/asan_fuzz.rs
@@ -67,12 +67,14 @@ fn asan_crashes() {
     thread::sleep(Duration::from_secs(30));
     kill_subprocesses_recursively(&format!("{}", fuzzer.id()));
 
-    assert!(temp_dir_path
-        .join("asan-fuzz")
-        .join("afl")
-        .join("mainaflfuzzer")
-        .join("fuzzer_stats")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("asan-fuzz")
+            .join("afl")
+            .join("mainaflfuzzer")
+            .join("fuzzer_stats")
+            .is_file()
+    );
     assert!(
         fs::read_dir(
             temp_dir_path

--- a/tests/url_fuzz.rs
+++ b/tests/url_fuzz.rs
@@ -79,18 +79,22 @@ fn integration() {
     thread::sleep(Duration::from_secs(30));
     kill_subprocesses_recursively(&format!("{}", fuzzer.id()));
 
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("afl")
-        .join("mainaflfuzzer")
-        .join("fuzzer_stats")
-        .is_file());
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("honggfuzz")
-        .join("url-fuzz")
-        .join("input")
-        .is_dir());
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("afl")
+            .join("mainaflfuzzer")
+            .join("fuzzer_stats")
+            .is_file()
+    );
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("honggfuzz")
+            .join("url-fuzz")
+            .join("input")
+            .is_dir()
+    );
 
     // We resume fuzzing
     // cargo ziggy fuzz -j 2 -t 5
@@ -120,11 +124,13 @@ fn integration() {
         .expect("failed to run `cargo ziggy minimize`");
 
     assert!(minimization.success());
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("logs")
-        .join("minimization_afl.log")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("logs")
+            .join("minimization_afl.log")
+            .is_file()
+    );
 
     fs::remove_dir_all(temp_dir_path.join("url-fuzz").join("corpus_minimized")).unwrap();
 
@@ -139,11 +145,13 @@ fn integration() {
         .expect("failed to run `cargo ziggy minimize`");
 
     assert!(minimization.success());
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("logs")
-        .join("minimization_honggfuzz.log")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("logs")
+            .join("minimization_honggfuzz.log")
+            .is_file()
+    );
 
     // cargo ziggy cover
     let coverage = process::Command::new(&cargo_ziggy)
@@ -155,11 +163,13 @@ fn integration() {
         .expect("failed to run `cargo ziggy cover`");
 
     assert!(coverage.success());
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("coverage")
-        .join("index.html")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("coverage")
+            .join("index.html")
+            .is_file()
+    );
 
     // cargo ziggy plot
     let plot = process::Command::new(&cargo_ziggy)
@@ -171,11 +181,13 @@ fn integration() {
         .expect("failed to run `cargo ziggy plot`");
 
     assert!(plot.success());
-    assert!(temp_dir_path
-        .join("url-fuzz")
-        .join("plot")
-        .join("index.html")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("url-fuzz")
+            .join("plot")
+            .join("index.html")
+            .is_file()
+    );
 }
 
 #[allow(clippy::zombie_processes)]
@@ -294,9 +306,11 @@ fn fuzz_binary() {
     thread::sleep(Duration::from_secs(30));
     kill_subprocesses_recursively(&format!("{}", fuzzer.id()));
 
-    assert!(temp_dir_path
-        .join("afl/mainaflfuzzer/fuzzer_stats")
-        .is_file());
+    assert!(
+        temp_dir_path
+            .join("afl/mainaflfuzzer/fuzzer_stats")
+            .is_file()
+    );
 
     // We resume fuzzing
     // cargo ziggy fuzz -j 2 -t 5


### PR DESCRIPTION
Mostly formatting changes (`cargo fmt`), for CI the upgrade to latest honggfuzz is needed.