### PR TITLE
coverage-worker flag path construction fix

### DIFF
--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -176,7 +176,9 @@ impl Fuzz {
             let profile_bin = cx
                 .target_dir
                 .join(format!("coverage/debug/{}", cx.bin_target));
-            let profile_base = cx.target_dir.join("coverage/debug/deps/coverage-worker.profraw");
+            let profile_base = cx
+                .target_dir
+                .join("coverage/debug/deps/coverage-worker.profraw");
             Some(crate::coverage::Cfg::new(profile_bin, profile_base)?)
         } else {
             None

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -176,7 +176,7 @@ impl Fuzz {
             let profile_bin = cx
                 .target_dir
                 .join(format!("coverage/debug/{}", cx.bin_target));
-            let profile_base = cx.target_dir.join("coverage/debug/deps/coverage-");
+            let profile_base = cx.target_dir.join("coverage/debug/deps/coverage-worker.profraw");
             Some(crate::coverage::Cfg::new(profile_bin, profile_base)?)
         } else {
             None
@@ -233,7 +233,7 @@ impl Fuzz {
                         let profile_bin = cx.target_dir.join(format!("coverage/debug/{target}"));
                         let profile_base = cx
                             .target_dir
-                            .join("coverage/debug/deps/coverage-")
+                            .join("coverage/debug/deps")
                             .as_std_path()
                             .to_path_buf();
                         let entries = std::fs::read_dir(&main_corpus).unwrap();
@@ -250,7 +250,8 @@ impl Fuzz {
                             });
                             if potentially_new && let Some(hash) = entry.file_name() {
                                 let profile_file = {
-                                    let mut name = hash.to_os_string();
+                                    let mut name = std::ffi::OsString::from("coverage-");
+                                    name.push(hash);
                                     name.push(".profraw");
                                     profile_base.join(name)
                                 };

--- a/src/bin/cargo-ziggy/fuzz.rs
+++ b/src/bin/cargo-ziggy/fuzz.rs
@@ -227,6 +227,7 @@ impl Fuzz {
                     let coverage_now_running = Arc::clone(&coverage_now_running);
                     let cx = cx.clone();
                     let cfg = coverage_cfg.clone().unwrap();
+                    let terminate = Arc::clone(&common.terminate);
                     thread::spawn(move || {
                         let mut seen_new_entry = false;
                         let prev_start_time =
@@ -285,8 +286,11 @@ impl Fuzz {
                         };
 
                         {
+                            // poison mutex on failure
                             let mut guard = coverage_now_running.lock().unwrap();
-                            res.unwrap();
+                            if !terminate.load(std::sync::atomic::Ordering::Acquire) {
+                                res.unwrap();
+                            }
                             *guard = false;
                         }
                         *cov_end_time.lock().unwrap() = Instant::now();

--- a/tests/url_fuzz.rs
+++ b/tests/url_fuzz.rs
@@ -417,3 +417,47 @@ fn clean() {
         assert!(!hfuzz_build_path.exists(), "honggfuzz harness not cleaned");
     }
 }
+
+#[allow(clippy::zombie_processes)]
+#[test]
+fn coverage_worker() {
+    let _guard = exclusive_guard();
+    let temp_dir = tempfile::tempdir().unwrap();
+    let output_dir = temp_dir.path().join("output");
+    let target_dir = temp_dir.path().join("target");
+    let metadata = cargo_metadata::MetadataCommand::new().exec().unwrap();
+    let workspace_root: PathBuf = metadata.workspace_root.into();
+    let cargo_ziggy = metadata.target_directory.join("debug/cargo-ziggy");
+    let fuzzer_directory = workspace_root.join("examples/url");
+
+    // cargo ziggy build
+    let build_status = process::Command::new(&cargo_ziggy)
+        .arg("ziggy")
+        .arg("build")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(&fuzzer_directory)
+        .status()
+        .expect("failed to run `cargo ziggy build`");
+    assert!(build_status.success(), "`cargo ziggy build` failed");
+
+    // cargo ziggy fuzz -j 2 -t 5 -o temp_dir
+    let mut fuzzer = process::Command::new(&cargo_ziggy)
+        .arg("ziggy")
+        .arg("fuzz")
+        .arg("-j2")
+        .arg("-t5")
+        .arg("-G100")
+        .arg("--coverage-worker")
+        .arg("--coverage-interval=0")
+        .arg("--corpus-sync-interval=0")
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .env("ZIGGY_OUTPUT", output_dir)
+        .env("AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES", "1")
+        .env("AFL_SKIP_CPUFREQ", "1")
+        .current_dir(&fuzzer_directory)
+        .spawn()
+        .expect("failed to run `cargo ziggy fuzz`");
+    thread::sleep(Duration::from_secs(30));
+    assert!(matches!(fuzzer.try_wait(), Ok(None)));
+    kill_subprocesses_recursively(&format!("{}", fuzzer.id()));
+}


### PR DESCRIPTION
fixed the `--coverage-worker` of `ziggy fuzz` by changing the path construction so the correct path to the profraw files can be found.

fixes #171 