### PR TITLE
fix triage: pass correct afl output path to casr-afl

### DIFF
--- a/src/bin/cargo-ziggy/triage.rs
+++ b/src/bin/cargo-ziggy/triage.rs
@@ -7,7 +7,12 @@ impl Triage {
         eprintln!("Running CASR triage on crashes");
 
         let cx = Context::new(common, self.target.clone())?;
-        let input_dir = cx.target_dir.join("afl");
+        let input_dir = self
+            .ziggy_output
+            .join(&cx.bin_target)
+            .join("afl")
+            .display()
+            .to_string();
 
         let triage_dir = self
             .output


### PR DESCRIPTION
Fix a regression in the `triage` command by passing the AFL output directory to casr-afl instead of the target directory.