### PR TITLE
fix(cmplog): Ensure AFL++ plugins are installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup component add rust-src llvm-tools
       - run: cargo install cargo-afl honggfuzz
-      - if: ${{ matrix.toolchain == 'beta' || matrix.toolchain == 'nightly' }}
+      - if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo afl config --plugins --build
       - run: cargo install --path . --verbose
       - if: ${{ matrix.toolchain == 'stable' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup component add rust-src llvm-tools
       - run: cargo install cargo-afl honggfuzz
+      - name: Install LLVM matching the nightly toolchain (for AFL++ cmplog plugins)
+        if: ${{ matrix.toolchain == 'nightly' }}
+        run: |
+          # afl.rs builds the AFL++ LLVM pass plugins against rustc's embedded
+          # LLVM, so we need a matching `llvm-config-<major>` on PATH.
+          LLVM_VERSION=$(rustc --version --verbose | sed -n 's/^LLVM version: \([0-9]*\).*/\1/p')
+          echo "Nightly toolchain uses LLVM ${LLVM_VERSION}"
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh "${LLVM_VERSION}"
+          sudo apt-get install -y "llvm-${LLVM_VERSION}-dev" "libclang-${LLVM_VERSION}-dev"
+          llvm-config-"${LLVM_VERSION}" --version
       - if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo afl config --plugins --build
       - run: cargo install --path . --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup component add rust-src llvm-tools
       - run: cargo install cargo-afl honggfuzz
+      - if: ${{ matrix.toolchain == 'beta' || matrix.toolchain == 'nightly' }}
+        run: cargo afl config --plugins --build
       - run: cargo install --path . --verbose
       - if: ${{ matrix.toolchain == 'stable' }}
         run: diff <(awk '/^```$/ && p{exit} p; /^\$ cargo ziggy/{p=1}' README.md) <(cargo ziggy 2>&1)

--- a/src/bin/cargo-ziggy/build.rs
+++ b/src/bin/cargo-ziggy/build.rs
@@ -3,12 +3,27 @@ use anyhow::{Context as _, Result, bail};
 use console::style;
 use std::{env, process};
 
+fn is_using_nightly_toolchain() -> bool {
+    let out = process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .expect("failed to launch rustc");
+
+    String::from_utf8_lossy(&out.stdout).contains("nightly")
+}
+
 impl Build {
     /// Build the fuzzers
     pub fn build(&self, common: &Common) -> Result<(), anyhow::Error> {
         // No fuzzers for you
         if self.no_afl && self.no_honggfuzz {
             bail!("Pick at least one fuzzer");
+        }
+
+        let is_nightly = is_using_nightly_toolchain();
+
+        if self.asan && !is_nightly {
+            bail!("ASAN requires nightly toolchain");
         }
 
         let cx = Context::new(common, self.target.clone())?;
@@ -34,14 +49,20 @@ impl Build {
             let mut rust_flags = env::var("RUSTFLAGS").unwrap_or_default();
             let mut rust_doc_flags = env::var("RUSTDOCFLAGS").unwrap_or_default();
 
-            // First fuzzer we build: AFL++
-            let run = common
-                .cargo()
-                .args(&afl_args)
+            let mut cmd = common.cargo();
+            cmd.args(&afl_args)
                 .env("AFL_QUIET", "1")
                 .env("AFL_LLVM_CMPLOG", "1") // for afl.rs feature "plugins"
                 .env("RUSTFLAGS", &rust_flags)
-                .env("RUSTDOCFLAGS", &rust_doc_flags)
+                .env("RUSTDOCFLAGS", &rust_doc_flags);
+
+            if is_nightly {
+                // make afl.rs check that AFL++ plugins are installed and fail otherwise
+                cmd.env("AFLRS_REQUIRE_PLUGINS", "1");
+            }
+
+            // First fuzzer we build: AFL++
+            let run = cmd
                 .spawn()?
                 .wait()
                 .context("Error spawning afl build command")?;
@@ -70,6 +91,7 @@ impl Build {
                     .env("AFL_QUIET", "1")
                     // need to specify for afl.rs so that we build with -Copt-level=0
                     .env("AFL_OPT_LEVEL", "0")
+                    .env("AFLRS_REQUIRE_PLUGINS", "1")
                     .env("AFL_LLVM_CMPLOG", "1") // for afl.rs feature "plugins"
                     .env("RUSTFLAGS", rust_flags)
                     .env("RUSTDOCFLAGS", rust_doc_flags)


### PR DESCRIPTION
Ensure that AFL++ plugins are installed when fuzzing. Running only `cargo afl config --build` will build AFL++ without plugins, resulting in the fuzzing binary not using CMPLOG at all. 

When setting the `AFLRS_REQUIRE_PLUGINS` env variable, afl.rs will [check](https://github.com/rust-fuzz/afl.rs/blob/9187d10738cee06cc5eb64311a4330c554764bc4/cargo-afl/src/main.rs#L301-L306) that AFL++ plugins are actually installed and fail otherwise.

