### PR TITLE
docs(readme): mention nightly toolchain requirement for ASAN/CMPLOG

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 - 🎯 easy coverage report generation
 - 😶‍🌫️ Arbitrary trait support
 
+> Note: Fuzzing features such as CMPLOG or ASAN require ziggy to be built with the Rust nightly toolchain.
+
 Features will also include:
 
 - 🐇 [LibAFL](https://github.com/aflplusplus/libafl) integration


### PR DESCRIPTION
As discussed, we should mention the need for the nightly Rust toolchain for ASAN / CMPLOG somewhere in the README.

Happy to change where and how this is documented :)