### PR TITLE
Fix clean subcommand

### DIFF
--- a/src/bin/cargo-ziggy/clean.rs
+++ b/src/bin/cargo-ziggy/clean.rs
@@ -7,20 +7,23 @@ impl Clean {
             return Ok(());
         };
         let clean = |target, target_triple: Option<&str>, try_release| -> Result<(), Error> {
-            let already_profile = self
-                .args
-                .iter()
-                .any(|arg| arg.as_encoded_bytes().starts_with(b"--profile") || arg == "--release");
-            let status = common
-                .cargo()
-                .arg("clean")
-                .arg("-q")
-                .args(&self.args)
-                .args(target_triple.map(|triple| format!("--target={triple}")))
-                .args((!already_profile && try_release).then_some("--release"))
-                .env("CARGO_TARGET_DIR", target_dir.join(target))
-                .status()
-                .expect("Error running cargo clean command");
+            let mut command = common.cargo();
+            command
+                .args(["clean", "-q"])
+                .env("CARGO_TARGET_DIR", target_dir.join(target));
+            if !self.args.is_empty() {
+                command.args(&self.args);
+                if let Some(triple) = target_triple {
+                    command.arg(format!("--target={triple}"));
+                }
+                let already_profile = self.args.iter().any(|arg| {
+                    arg.as_encoded_bytes().starts_with(b"--profile") || arg == "--release"
+                });
+                if try_release && !already_profile {
+                    command.arg("--release");
+                }
+            }
+            let status = command.status().expect("Error running cargo clean command");
             if !status.success() {
                 bail!("Error cleaning up: Exited with {:?}", status.code());
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,10 @@ where
 {
     use std::{env, fs::File, io::Read};
     let file_names: Vec<String> = env::args().skip(1).collect();
-    if file_names.is_empty() {
-        panic!("pass in a file name as argument");
-    }
+    assert!(!file_names.is_empty(), "pass in a file name as argument");
+    let mut buffer = Vec::new();
     for file_name in file_names {
         println!("Now running {file_name}");
-        let mut buffer: Vec<u8> = Vec::new();
         let mut file = File::open(&file_name).unwrap_or_else(|e| {
             eprintln!("Could not open file: {e}");
             std::process::exit(1);
@@ -24,6 +22,7 @@ where
             std::process::exit(1);
         });
         closure(buffer.as_slice());
+        buffer.clear();
     }
 }
 

--- a/tests/url_fuzz.rs
+++ b/tests/url_fuzz.rs
@@ -415,6 +415,25 @@ fn clean() {
         assert!(clean_status.success(), "`cargo ziggy clean` failed");
         assert!(!afl_build_path.exists(), "afl harness not cleaned");
         assert!(!hfuzz_build_path.exists(), "honggfuzz harness not cleaned");
+
+        let build_status = process::Command::new(&cargo_ziggy)
+            .arg("ziggy")
+            .arg("build")
+            .env("CARGO_TARGET_DIR", temp_dir_path)
+            .current_dir(&fuzzer_directory)
+            .status()
+            .expect("failed to run `cargo ziggy build`");
+        assert!(build_status.success(), "`cargo ziggy build` failed");
+
+        let clean_status = process::Command::new(&cargo_ziggy)
+            .args(["ziggy", "clean"])
+            .env("CARGO_TARGET_DIR", temp_dir_path)
+            .current_dir(&fuzzer_directory)
+            .status()
+            .expect("failed to run `cargo ziggy clean`");
+        assert!(clean_status.success(), "`cargo ziggy clean` failed");
+        assert!(!temp_dir_path.join("afl").exists(), "afl not cleaned");
+        assert!(!temp_dir_path.join("honggfuzz").exists(), "afl not cleaned");
     }
 }
 


### PR DESCRIPTION
When invoking `cargo ziggy clean`, it did not remove all build artifacts from the afl and honggfuzz target directory. The old integration test was calling clean only with a package specification and thus was not expected to remove the whole fuzzer's target directory.