### PR TITLE
Remove dependency on tokio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Cargo sort
-        run: cargo install cargo-sort && cargo sort --check --check-format
+        run: cargo install cargo-sort && cargo sort --check --check-format --workspace
       - name: Format
         run: cargo fmt --check
       - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,12 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,17 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,12 +597,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -949,20 +926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "signal-hook-registry",
- "windows-sys",
-]
-
-[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,10 +1007,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wait-timeout"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -1389,8 +1355,8 @@ dependencies = [
  "tempfile",
  "thread_local",
  "time-humanize",
- "tokio",
  "twox-hash",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ cli = [
     "tempfile",
     "thread_local",
     "time-humanize",
-    "tokio",
     "twox-hash",
+    "wait-timeout",
 ]
 coverage = []
 
@@ -64,12 +64,8 @@ target-triple = { version = "1.0.0", optional = true }
 tempfile = { version = "3.27.0", optional = true }
 thread_local = { version = "1.1.9", optional = true }
 time-humanize = { version = "0.1.3", optional = true }
-tokio = { version = "1.50.0", features = [
-    "process",
-    "rt",
-    "time",
-], optional = true }
 twox-hash = { version = "2.1.2", optional = true }
+wait-timeout = { version = "0.2.1", optional = true }
 
 [lints.clippy]
 needless_doctest_main = "allow"

--- a/examples/unstable/Cargo.toml
+++ b/examples/unstable/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-[dependencies]
-ziggy = { path = "../../", default-features = false }
-
 [features]
 fuzzing = []
+
+[dependencies]
+ziggy = { path = "../../", default-features = false }

--- a/examples/url/Cargo.toml
+++ b/examples/url/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+fuzzing = []
+
 [dependencies]
 url = "2.5.0"
 ziggy = { path = "../../", default-features = false }
-
-[features]
-fuzzing = []

--- a/src/bin/cargo-ziggy/main.rs
+++ b/src/bin/cargo-ziggy/main.rs
@@ -419,7 +419,6 @@ pub struct Common {
     terminate: Arc<AtomicBool>,
     sigs_done: Option<()>,
     pub cargo_path: PathBuf,
-    runtime: OnceLock<tokio::runtime::Runtime>,
     metadata: OnceLock<Option<cargo_metadata::Metadata>>,
 }
 
@@ -431,7 +430,6 @@ impl Common {
             cargo_path: std::env::var("CARGO")
                 .unwrap_or_else(|_| String::from("cargo"))
                 .into(),
-            runtime: OnceLock::new(),
             metadata: OnceLock::new(),
         }
     }
@@ -469,15 +467,6 @@ impl Common {
         let mut cmd = std::process::Command::new(&self.cargo_path);
         cmd.stdin(std::process::Stdio::null());
         cmd
-    }
-
-    fn async_runtime(&self) -> &tokio::runtime::Runtime {
-        self.runtime.get_or_init(|| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed building tokio runtime")
-        })
     }
 
     /// Cached `cargo metadata`

--- a/src/bin/cargo-ziggy/run.rs
+++ b/src/bin/cargo-ziggy/run.rs
@@ -7,6 +7,7 @@ use std::{
     os::unix::process::ExitStatusExt,
     path::{Path, PathBuf},
 };
+use wait_timeout::ChildExt;
 
 impl Run {
     // Run inputs
@@ -100,10 +101,9 @@ impl Run {
         };
 
         let runner = Runner::new(
-            common.async_runtime(),
             runner_path.as_std_path(),
             self.timeout
-                .map(|s| tokio::time::Duration::from_secs(u64::from(s))),
+                .map(|s| std::time::Duration::from_secs(u64::from(s))),
         );
 
         for file in input_files {
@@ -154,47 +154,43 @@ fn collect_dirs_recursively(
 }
 
 struct Runner<'a> {
-    rt: &'a tokio::runtime::Runtime,
     path: &'a Path,
-    timeout: Option<tokio::time::Duration>,
+    timeout: Option<std::time::Duration>,
 }
 
 impl<'a> Runner<'a> {
-    fn new(
-        rt: &'a tokio::runtime::Runtime,
-        path: &'a Path,
-        timeout: Option<tokio::time::Duration>,
-    ) -> Self {
-        Self { rt, path, timeout }
+    fn new(path: &'a Path, timeout: Option<std::time::Duration>) -> Self {
+        Self { path, timeout }
     }
 
     fn run(&self, seed: &Path) -> Status {
-        self.rt.block_on(async {
-            let mut child = match tokio::process::Command::new(self.path)
-                .arg(seed)
-                .env("RUST_BACKTRACE", "full")
-                .spawn()
-                .context("⚠️  couldn't spawn the runner process")
-            {
-                Ok(child) => child,
-                Err(e) => return e.into(),
-            };
-            let res = if let Some(duration) = self.timeout {
-                if let Ok(res) = tokio::time::timeout(duration, child.wait()).await {
-                    res
-                } else {
-                    let _ = child.start_kill();
+        let mut child = match std::process::Command::new(self.path)
+            .arg(seed)
+            .env("RUST_BACKTRACE", "full")
+            .spawn()
+            .context("⚠️  couldn't spawn the runner process")
+        {
+            Ok(child) => child,
+            Err(e) => return e.into(),
+        };
+        let res = if let Some(timeout) = self.timeout {
+            match child.wait_timeout(timeout) {
+                Ok(None) => {
+                    // timed out
+                    let _ = child.kill();
                     return Status::Timeout;
                 }
-            } else {
-                child.wait().await
+                Ok(Some(status)) => Ok(status),
+                Err(e) => Err(e),
             }
-            .context("⚠️  couldn't wait for the runner process");
-            match res {
-                Ok(status) => Status::Ok(status),
-                Err(e) => e.into(),
-            }
-        })
+        } else {
+            child.wait()
+        }
+        .context("⚠️  couldn't wait for the runner process");
+        match res {
+            Ok(status) => Status::Ok(status),
+            Err(e) => e.into(),
+        }
     }
 }
 


### PR DESCRIPTION
Alternative implementation of #183 . This is faster in case of multiple seeds (n=1800), a test on my machine showed
```
# PR 183
Benchmark 1: cargo ziggy run -t 10
  Time (mean ± σ):     24.181 s ±  0.148 s    [User: 6.290 s, System: 2.029 s]
  Range (min … max):   23.938 s … 24.405 s    10 runs
 
# THIS PR
Benchmark 1: cargo ziggy run -t 10
  Time (mean ± σ):      7.968 s ±  0.262 s    [User: 6.056 s, System: 1.906 s]
  Range (min … max):    7.660 s …  8.487 s    10 runs
  ```